### PR TITLE
Add quiet mode to suppress all output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,10 +13,10 @@ created: $CREATED by $AUTHOR
 *******************************
 i3ass - installation script
 ---------------------------
-This script prompts you for a FOLDER, if it isn't 
-given as an argument. When the FOLDER is known, 
+This script prompts you for a FOLDER, if it isn't
+given as an argument. When the FOLDER is known,
 FOLDER will be created if it doesn't exist and
-all scripts in the i3ass suite will be symlinked 
+all scripts in the i3ass suite will be symlinked
 to FOLDER and made executable.
 
 usage
@@ -25,6 +25,8 @@ usage
 
 | option | argument | function                   |
 |:-------|:---------|:---------------------------|
+| -q     |          | quiet mode, show no output |
+|        |          | PATH must be set           |
 | -v     |          | show version info and exit |
 | -h     |          | show this help and exit    |
 
@@ -37,7 +39,31 @@ contact
 $CONTACT
 "
 
-while getopts :vh option
+FLD_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+QUIET=false
+
+# create symlinks for all helper scripts
+function link_scripts {
+  FLD_TRG="$1"
+  FLD_TRG="${FLD_TRG/'~'/$HOME}"
+  [[ -z "$FLD_TRG" ]] \
+    && echo \
+    && echo "NO folder, NO installation." && exit 1
+
+  [[ ! -d "$FLD_TRG" ]] && mkdir -p "$FLD_TRG"
+
+  for s in ${FLD_THIS}/*; do
+    [[ ! -d $s ]] && continue
+    FIL_TRG="$s/${s##*/}"
+    [[ ! -f "$FIL_TRG" ]] && continue
+    ln -s "$FIL_TRG" "${FLD_TRG}/${s##*/}"
+    chmod +x "${FLD_TRG}/${s##*/}"
+    [ ! $QUIET ] && echo "Link created: ${FLD_TRG}/${s##*/}"
+  done
+}
+
+
+while getopts :vhq option
 do
   case "${option}" in
     v) printf '%s\n' \
@@ -45,16 +71,13 @@ do
          "updated: $UPDATED by $AUTHOR"
        exit ;;
     h) printf '%s\n' "${about}" && exit ;;
+    q) QUIET=true; link_scripts "${2}" && exit ;;
   esac
 done
 
-FLD_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 [[ ${FLD_THIS##*/} != i3ass ]] \
-  && echo "install.sh is not in i3ass folder" && exit
-
-FLD_TRG="$1"
-FLD_TRG="${FLD_TRG/'~'/$HOME}"
+  && echo "install.sh is not in i3ass folder" && exit 1
 
 clear
 
@@ -73,13 +96,14 @@ printf '%s\n' \
 
 echo
 
+FLD_TRG="$1"
 if [[ -z "$FLD_TRG" ]]; then
   echo "example folder: (~/i3ass)"
   read -rp 'Specify target folder: ' FLD_TRG
   FLD_TRG="${FLD_TRG/'~'/$HOME}"
   [[ -z "$FLD_TRG" ]] \
     && echo \
-    && echo "NO folder, NO installation." && exit
+    && echo "NO folder, NO installation." && exit 1
 fi
 
 [[ ${FLD_TRG:0:1} != '/' ]] && FLD_TRG="$(pwd)/$FLD_TRG"
@@ -91,16 +115,7 @@ echo
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-  [[ ! -d "$FLD_TRG" ]] && mkdir -p "$FLD_TRG"
-
-  for s in ${FLD_THIS}/*; do
-    [[ ! -d $s ]] && continue
-    FIL_TRG="$s/${s##*/}"
-    [[ ! -f "$FIL_TRG" ]] && continue
-    ln -s "$FIL_TRG" "${FLD_TRG}/${s##*/}"
-    chmod +x "${FLD_TRG}/${s##*/}"
-    echo "Link created: ${FLD_TRG}/${s##*/}"
-  done
+  link_scripts ${FLD_TRG}
   echo
   printf '%s\n' \
   "Thank you for installing i3ass. All commands" \
@@ -113,5 +128,5 @@ then
   " " \
   "Happy tiling!"
 else
-  echo "NO approval, NO installation." && exit
+  echo "NO approval, NO installation." && exit 1
 fi


### PR DESCRIPTION
I setup i3ass as part of an automated installation. I could easily symlink the helperscripts myself, but I would prefer to use your install.sh command. That way, new scripts or changes in your repo will automatically be used.

This patch mainly extracts the symlinking part into a new function. I tried to avoid duplication without adding major changes.